### PR TITLE
feat: Support .NET restoring (#6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base on Node + Alpine for minimal size
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/runtime:9.0
 
 RUN set -uex; \
     apt-get update; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 # 1. Base on Node + Alpine for minimal size
-FROM node:22-alpine
+FROM mcr.microsoft.com/dotnet/sdk:9.0
+
+RUN set -uex; \
+    apt-get update; \
+    apt-get install -y ca-certificates curl gnupg; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    NODE_MAJOR=22; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install nodejs -y;
 
 # 2. Install bash, GNU findutils, and your global CLIs
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,13 @@ RUN set -uex; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list; \
     apt-get update; \
-    apt-get install nodejs -y;
+    apt-get install nodejs bash findutils -y; \
+    npm install -g sass typescript;
 
-# 2. Install bash, GNU findutils, and your global CLIs
-RUN apk add --no-cache \
-      bash \
-      findutils \
-    && npm install -g sass typescript
-
-# 3. Set working directory for your mounted project
+# 2. Set working directory for your mounted project
 WORKDIR /src
 
-# 4. Run whatever script is in the project root
+# 3. Run whatever script is in the project root
 #    – if the project’s build-frontend.sh isn’t executable, you can still
 #      run it via bash.
 ENTRYPOINT ["bash", "./build-frontend.sh"]


### PR DESCRIPTION
Description
=======
At the moment we cannot use the [DEV-tool](https://github.com/hansen-consultancy/Dev) out of the box, since `vidyano.js` is missing, which is usually generated by `libman` (triggered by `dotnet restore`)

This PR changes the container to start off from a .NET image, and add nodejs 22 to it.

Linked issues
========
- Closes #6 

Trace
====
- [dotnet/docker github repo](https://github.com/dotnet/dotnet-docker/blob/main/README.runtime.md)
- `dotnet/runtime:9.0` docker image
- `docker build .`

![image](https://github.com/user-attachments/assets/95bfe38d-ed9e-4183-8d23-2b33fdec8137)
![image](https://github.com/user-attachments/assets/64962620-70f4-45e0-aee0-fe31b3fccb08)


Screenshots
=======
![image](https://github.com/user-attachments/assets/3314a18e-bc19-494a-aaa1-14f3c8bc65ba)
